### PR TITLE
Fix for Managed Records in 12.3

### DIFF
--- a/PascalZMQ.pas
+++ b/PascalZMQ.pas
@@ -366,7 +366,7 @@ type
 
       Parameters:
         AValue: the value to push. }
-    procedure PushProtocolBuffer<T: record>(const AValue: T); overload;
+    procedure PushProtocolBuffer<T{$IF (RTLVersion < 36)}: record{$ENDIF}>(const AValue: T); overload;
     procedure PushProtocolBuffer(const ARecordType: Pointer; const AValue); overload;
   public
     { Popping frames }
@@ -2181,4 +2181,4 @@ initialization
 finalization
   ZMQFinalizeDebugMode;
 
-end.
+end.


### PR DESCRIPTION
Fixes #7 Managed Records in 12.3. 
This adds the record constraint only for older compilers, thus allowing Delphi 12.3 to compile the file.